### PR TITLE
Fix#2 - Standartization of decimal marks to en-US

### DIFF
--- a/ScannerTemplate/Program.cs
+++ b/ScannerTemplate/Program.cs
@@ -1,19 +1,19 @@
-﻿/* 
+/*
  * Optical Mark Recognition Engine
  * Copyright 2015, Justin Fyfe
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you 
- * may not use this file except in compliance with the License. You may 
- * obtain a copy of the License at 
- * 
- * http://www.apache.org/licenses/LICENSE-2.0 
- * 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations under 
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
- * 
+ *
  * Author: Justin
  * Date: 4-16-2015
  */
@@ -28,13 +28,19 @@ namespace ScannerTemplate
 {
     static class Program
     {
-        /// <summary>
+        /// <summary>µ
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
         static void Main()
         {
             Application.EnableVisualStyles();
+
+            // Standardtization of decimal mark
+            Application.SetCompatibleTextRenderingDefault(false);
+            System.Globalization.CultureInfo cultureInfo = new System.Globalization.CultureInfo("en-US");
+            Application.CurrentCulture = cultureInfo;
+
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new frmMain());
         }


### PR DESCRIPTION
I included the code suggested by @OntJames in issue #2 so that the decimal marks would always be "en-US"